### PR TITLE
Added Defold library functionality to game.project

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,13 @@ Defold Game Center native extension. Only support basic funtionalities for now.
 
 ## Usage:
 ```
-Copy the whole gamecenter folder to your project root folder.
+You can use Defold-LFS in your own project by adding this project as a [Defold library dependency](http://www.defold.com/manuals/libraries/). Open your game.project file and in the dependencies field under project add:
+
+	https://github.com/gregorgullwi/vinhvd/archive/master.zip
+
+Or point to the ZIP file of a [specific release](https://github.com/vinhvd/defoldgamecenter/releases).
 ```
+
 ## Constants:
 - ###### Leaderboard time scope
 ```lua

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Defold Game Center native extension. Only support basic funtionalities for now.
 You can use Defold-LFS in your own project by adding this project as a [Defold library dependency](http://www.defold.com/manuals/libraries/). Open your game.project file and in the dependencies field under project add:
 
 ```
-	https://github.com/gregorgullwi/vinhvd/archive/master.zip
+	https://github.com/vinhvd/defoldgamecenter/archive/master.zip
 ```
 
 Or point to the ZIP file of a [specific release](https://github.com/vinhvd/defoldgamecenter/releases).

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 Defold Game Center native extension. Only support basic funtionalities for now. 
 
 ## Usage:
-```
 You can use Defold-LFS in your own project by adding this project as a [Defold library dependency](http://www.defold.com/manuals/libraries/). Open your game.project file and in the dependencies field under project add:
 
+```
 	https://github.com/gregorgullwi/vinhvd/archive/master.zip
+```
 
 Or point to the ZIP file of a [specific release](https://github.com/vinhvd/defoldgamecenter/releases).
-```
 
 ## Constants:
 - ###### Leaderboard time scope

--- a/game.project
+++ b/game.project
@@ -47,3 +47,5 @@ launch_image_2048x1536 = /supportfiles/ios/launch/iPad Landscape iOS 7-9@2x.png
 launch_image_2048x2732 = /supportfiles/ios/launch/2048_2732.png
 launch_image_2732x2048 = /supportfiles/ios/launch/2732-2048.png
 
+[library]
+include_dirs = gamecenter


### PR DESCRIPTION
Instead of cloning and manually copying the gamecenter folder, users can just add the GitHub master.zip path to their Defold project dependency paths.